### PR TITLE
[FIX][13.0] web_responsive: fix error open discuss on small devices by link

### DIFF
--- a/web_responsive/static/src/js/discuss.js
+++ b/web_responsive/static/src/js/discuss.js
@@ -159,7 +159,7 @@ odoo.define("web_responsive.Discuss", function(require) {
          * @returns {Promise}
          */
         _updateContent: function(type) {
-            const inMailbox = type.startsWith("mailbox_");
+            const inMailbox = typeof type === "string" ? type.startsWith("mailbox_") : false;
             if (!inMailbox && this._isInInboxTab()) {
                 // We're leaving the inbox, so store the thread scrolltop
                 this._storeThreadState();
@@ -208,7 +208,7 @@ odoo.define("web_responsive.Discuss", function(require) {
         },
 
         _updateButtons: function(type) {
-            const inMailbox = type.startsWith("mailbox_");
+            const inMailbox = typeof type === "string" ? type.startsWith("mailbox_") : false;
             // Update control panel
             this.$buttons
                 .find("button")


### PR DESCRIPTION
Trên các thiết bị có màn hình nhỏ (điện thoại), người dùng mở 1 cửa sổ chat cụ thể bằng việc copy pase link sẽ bị lỗi do type là kiểu int.